### PR TITLE
path to the output files must be absolute

### DIFF
--- a/ffcuesplitter/cuesplitter.py
+++ b/ffcuesplitter/cuesplitter.py
@@ -6,7 +6,7 @@ Porpose: FFmpeg based audio splitter for Cue sheet files
 Platform: MacOs, Gnu/Linux, FreeBSD
 Writer: jeanslack <jeanlucperni@gmail.com>
 license: GPL3
-Rev: February 03 2022
+Rev: February 06 2022
 Code checker: flake8 and pylint
 ####################################################################
 
@@ -339,6 +339,7 @@ class FFCueSplitter(FFMpeg):
             self.testpatch = True
 
         self.check_cuefile()
+        curdir = os.getcwd()
         os.chdir(self.kwargs['dirname'])
 
         with open(self.kwargs['filename'], 'rb') as file:
@@ -349,3 +350,4 @@ class FFCueSplitter(FFMpeg):
                                      encoding=self.cue_encoding['encoding'])
         self.cue = parser.run()
         self.deflacue_object_handler()
+        os.chdir(curdir)

--- a/ffcuesplitter/ffmpeg.py
+++ b/ffcuesplitter/ffmpeg.py
@@ -7,7 +7,7 @@ Platform: all platforms
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
 Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
-Rev: February 03 2022
+Rev: February 06 2022
 Code checker: flake8, pylint
 ########################################################
 
@@ -107,7 +107,8 @@ class FFMpeg:
             cmd = f'"{self.kwargs["ffmpeg_cmd"]}" '
             cmd += f' -loglevel {self.kwargs["ffmpeg_loglevel"]}'
             cmd += f" {meters[self.kwargs['progress_meter']]}"
-            cmd += f' -i "{track["FILE"]}"'
+            fpath = os.path.join(self.kwargs["dirname"], track["FILE"])
+            cmd += f' -i "{fpath}"'
             cmd += f" -ss {round(track['START'] / 44100, 6)}"  # ff to secs
             if 'END' in track:
                 cmd += f" -to {round(track['END'] / 44100, 6)}"  # ff to secs

--- a/ffcuesplitter/main.py
+++ b/ffcuesplitter/main.py
@@ -6,7 +6,7 @@ Porpose: provides command line arguments for ffcuesplitter
 Platform: MacOs, Gnu/Linux, FreeBSD
 Writer: jeanslack <jeanlucperni@gmail.com>
 license: GPL3
-Rev: February 03 2022
+Rev: February 06 2022
 Code checker: flake8, pylint
 ####################################################################
 
@@ -26,7 +26,6 @@ This file is part of FFcuesplitter.
     along with FFcuesplitter.  If not, see <http://www.gnu.org/licenses/>.
 """
 import argparse
-
 from ffcuesplitter.info import (__appname__,
                                 __description__,
                                 __version__,
@@ -39,7 +38,6 @@ from ffcuesplitter.exceptions import (InvalidFileError,
                                       FFProbeError,
                                       FFMpegError,
                                       )
-
 
 
 def main():


### PR DESCRIPTION
This PR fixes:
- Possible errors using `os.chdir()` without first setting a value to `os.getcwd()` for the next change.
- The `ffmpeg_arguments` method now returns arguments with absolute path names for input files as well. 
- Code refactoring.