### PR TITLE
Add option to encode to Opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ contained in the associated **"CUE"** sheet. It supports multiple CUE sheet
 encodings and many input formats (due to FFmpeg), including APE format, without
 need installing extra audio libs and packages. It has the ability to accept both
 files and directories as input while also working in recursive mode. Can be used
-both as a Python module and from command line.   
+both as a Python module and from command line.
 
 ## Features
 
 - Supports many input formats.
-- Convert to Wav, Flac, Ogg, Mp3 formats.
+- Convert to Wav, Flac, Ogg, Opus, and Mp3 formats.
 - Ability to copy source codec and format without re-encoding.
 - Batch mode processing is also available.
 - Accepts both multiple CUE file names and multiple folder path names.
@@ -41,7 +41,7 @@ both as a Python module and from command line.
 ```
 ffcuesplitter -i FILENAMES DIRNAMES [FILENAMES DIRNAMES ...]
               [-r]
-              [-f {wav,flac,mp3,ogg,copy}]
+              [-f {wav,flac,mp3,ogg,opus,copy}]
               [-o OUTPUTDIR]
               [-c {artist+album,artist,album}]
               [-ow {ask,never,always}]
@@ -55,18 +55,18 @@ ffcuesplitter -i FILENAMES DIRNAMES [FILENAMES DIRNAMES ...]
               [--version]
 ```
 
-**Examples**   
+**Examples**
 
-`ffcuesplitter -i 'inputfile_1.cue' 'inputfile_2.cue' 'inputfile_3.cue'`   
+`ffcuesplitter -i 'inputfile_1.cue' 'inputfile_2.cue' 'inputfile_3.cue'`
 
-Batch file processing to split and convert to default audio `flac` format.   
+Batch file processing to split and convert to default audio `flac` format.
 
-`ffcuesplitter -i '/User/music/collection/inputfile.cue' -f ogg -o 'my-awesome-tracklist'`   
+`ffcuesplitter -i '/User/music/collection/inputfile.cue' -f ogg -o 'my-awesome-tracklist'`
 
 To splits the individual audio tracks into `ogg` format
-and saves them in the 'my-awesome-tracklist' folder.   
+and saves them in the 'my-awesome-tracklist' folder.
 
-**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**   
+**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**
 ***
 
 ### Using Python
@@ -75,7 +75,7 @@ and saves them in the 'my-awesome-tracklist' folder.
 >>> from ffcuesplitter.cuesplitter import FFCueSplitter
 ```
 
-Splittings:   
+Splittings:
 
 ```python
 >>> split = FFCueSplitter(filename='filename.cue')
@@ -83,7 +83,7 @@ Splittings:
 >>> split.do_operations()
 ```
 
-Get data tracks and FFmpeg args:   
+Get data tracks and FFmpeg args:
 
 ```python
 >>> data = FFCueSplitter('filename.cue', dry=True)
@@ -93,20 +93,20 @@ Get data tracks and FFmpeg args:
 >>> data.ffmpeg_arguments()
 ```
 
-For arguments meaning and more details, type `help(FFCueSplitter)`   
+For arguments meaning and more details, type `help(FFCueSplitter)`
 
-**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**   
+**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**
 ***
 
 ## Installation
 
-`python3 -m pip install ffcuesplitter`   
+`python3 -m pip install ffcuesplitter`
 
 ## License and Copyright
 
-Copyright (C) 2023 Gianluca Pernigotto   
-Author and Developer: Gianluca Pernigotto   
-Mail: <jeanlucperni@gmail.com>   
-License: GPL3 (see LICENSE file in the source folder)   
+Copyright (C) 2023 Gianluca Pernigotto
+Author and Developer: Gianluca Pernigotto
+Mail: <jeanlucperni@gmail.com>
+License: GPL3 (see LICENSE file in the source folder)
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ contained in the associated **"CUE"** sheet. It supports multiple CUE sheet
 encodings and many input formats (due to FFmpeg), including APE format, without
 need installing extra audio libs and packages. It has the ability to accept both
 files and directories as input while also working in recursive mode. Can be used
-both as a Python module and from command line.
+both as a Python module and from command line.   
 
 ## Features
 
@@ -55,18 +55,18 @@ ffcuesplitter -i FILENAMES DIRNAMES [FILENAMES DIRNAMES ...]
               [--version]
 ```
 
-**Examples**
+**Examples**   
 
-`ffcuesplitter -i 'inputfile_1.cue' 'inputfile_2.cue' 'inputfile_3.cue'`
+`ffcuesplitter -i 'inputfile_1.cue' 'inputfile_2.cue' 'inputfile_3.cue'`   
 
-Batch file processing to split and convert to default audio `flac` format.
+Batch file processing to split and convert to default audio `flac` format.   
 
-`ffcuesplitter -i '/User/music/collection/inputfile.cue' -f ogg -o 'my-awesome-tracklist'`
+`ffcuesplitter -i '/User/music/collection/inputfile.cue' -f ogg -o 'my-awesome-tracklist'`   
 
 To splits the individual audio tracks into `ogg` format
-and saves them in the 'my-awesome-tracklist' folder.
+and saves them in the 'my-awesome-tracklist' folder.   
 
-**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**
+**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**   
 ***
 
 ### Using Python
@@ -75,7 +75,7 @@ and saves them in the 'my-awesome-tracklist' folder.
 >>> from ffcuesplitter.cuesplitter import FFCueSplitter
 ```
 
-Splittings:
+Splittings:   
 
 ```python
 >>> split = FFCueSplitter(filename='filename.cue')
@@ -83,7 +83,7 @@ Splittings:
 >>> split.do_operations()
 ```
 
-Get data tracks and FFmpeg args:
+Get data tracks and FFmpeg args:   
 
 ```python
 >>> data = FFCueSplitter('filename.cue', dry=True)
@@ -93,20 +93,20 @@ Get data tracks and FFmpeg args:
 >>> data.ffmpeg_arguments()
 ```
 
-For arguments meaning and more details, type `help(FFCueSplitter)`
+For arguments meaning and more details, type `help(FFCueSplitter)`   
 
-**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**
+**For further information and other examples visit the [wiki page](https://github.com/jeanslack/FFcuesplitter/wiki)**   
 ***
 
 ## Installation
 
-`python3 -m pip install ffcuesplitter`
+`python3 -m pip install ffcuesplitter`   
 
 ## License and Copyright
 
-Copyright (C) 2023 Gianluca Pernigotto
-Author and Developer: Gianluca Pernigotto
-Mail: <jeanlucperni@gmail.com>
-License: GPL3 (see LICENSE file in the source folder)
+Copyright (C) 2023 Gianluca Pernigotto   
+Author and Developer: Gianluca Pernigotto   
+Mail: <jeanlucperni@gmail.com>   
+License: GPL3 (see LICENSE file in the source folder)   
 
 

--- a/ffcuesplitter/cuesplitter.py
+++ b/ffcuesplitter/cuesplitter.py
@@ -95,7 +95,7 @@ class FFCueSplitter(FFMpeg):
                 auto-create additional sub-folders,
                 one of ("artist+album", "artist", "album")
         outputformat:
-                output format, one of ("wav", "flac", "mp3", "ogg", "copy") .
+                output format, one of ("wav", "flac", "mp3", "ogg", "opus", "copy") .
         overwrite:
                 overwriting options, one of "ask", "never", "always".
         ffmpeg_cmd:

--- a/ffcuesplitter/cuesplitter.py
+++ b/ffcuesplitter/cuesplitter.py
@@ -95,7 +95,8 @@ class FFCueSplitter(FFMpeg):
                 auto-create additional sub-folders,
                 one of ("artist+album", "artist", "album")
         outputformat:
-                output format, one of ("wav", "flac", "mp3", "ogg", "opus", "copy") .
+                output format, one of
+                ("wav", "flac", "mp3", "ogg", "opus", "copy") .
         overwrite:
                 overwriting options, one of "ask", "never", "always".
         ffmpeg_cmd:

--- a/ffcuesplitter/ffmpeg.py
+++ b/ffcuesplitter/ffmpeg.py
@@ -43,11 +43,13 @@ class FFMpeg:
     """
     FFMpeg is a parent base class interface for FFCueSplitter.
     It represents FFmpeg command and arguments with their
-    sub-processing.
+    sub-processing. Note: Opus sample rate is always 48kHz for
+    fullband audio.
     """
     DATACODECS = {'wav': 'pcm_s16le -ar 44100',
                   'flac': 'flac -ar 44100',
                   'ogg': 'libvorbis -ar 44100',
+                  'opus': 'libopus',
                   'mp3': 'libmp3lame -ar 44100',
                   }
 

--- a/ffcuesplitter/main.py
+++ b/ffcuesplitter/main.py
@@ -80,7 +80,7 @@ def main():
                         required=False,
                         )
     parser.add_argument('-f', '--format-type',
-                        choices=["wav", "flac", "mp3", "ogg", "copy"],
+                        choices=["wav", "flac", "mp3", "ogg", "opus", "copy"],
                         help=("Preferred audio format to output, "
                               "default is 'flac'."),
                         required=False,


### PR DESCRIPTION
This adds the option to encode to Ogg Opus, my preferred codec.

My vim was setup to automatically remove trailing whitespaces from lines, leading to a few unrelated lines to be changed in the edited files. If this is a problem, I can change them back.

Thank you so much for this project! I've found it to be very useful. So much better than `shnsplit`...