### PR TITLE
ffcuesplitter: fix ValueError when processing the progress bar

### DIFF
--- a/ffcuesplitter/ffmpeg.py
+++ b/ffcuesplitter/ffmpeg.py
@@ -197,9 +197,9 @@ class FFMpeg:
 
                     for output in proc.stdout:
                         if "out_time_ms" in output.strip():
-                            out_time_ms_value = output.split('=')[1].strip()
-                            if out_time_ms_value.isdigit():
-                                s_processed = int(out_time_ms_value) / 1_000_000
+                            out_time_ms_val = output.split('=')[1].strip()
+                            if out_time_ms_val.isdigit():
+                                s_processed = int(out_time_ms_val) / 1_000_000
                                 percent = s_processed / seconds * 100
                                 progbar.update(round(percent) - progbar.n)
 

--- a/ffcuesplitter/ffmpeg.py
+++ b/ffcuesplitter/ffmpeg.py
@@ -197,9 +197,11 @@ class FFMpeg:
 
                     for output in proc.stdout:
                         if "out_time_ms" in output.strip():
-                            s_processed = int(output.split('=')[1]) / 1_000_000
-                            percent = s_processed / seconds * 100
-                            progbar.update(round(percent) - progbar.n)
+                            out_time_ms_value = output.split('=')[1].strip()
+                            if out_time_ms_value.isdigit():
+                                s_processed = int(out_time_ms_value) / 1_000_000
+                                percent = s_processed / seconds * 100
+                                progbar.update(round(percent) - progbar.n)
 
                     if proc.wait():  # error
                         logging.error("Popen proc.wait() Exit status %s",


### PR DESCRIPTION
ffmpeg show N/A at the start when processing the file. This patch check if it was a digit first before it converted into an integer.

Error before the patch:
`Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/bin/ffcuesplitter", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/ffcuesplitter/main.py", line 205, in main
    split.work_on_temporary_directory()
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/ffcuesplitter/user_service.py", line 179, in work_on_temporary_directory
    self.command_runner(args[0], args[1]['duration'])
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/ffcuesplitter/ffmpeg.py", line 148, in command_runner
    self.run_ffmpeg_command_with_progress(cmd, secs)
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/ffcuesplitter/ffmpeg.py", line 200, in run_ffmpeg_command_with_progress
    s_processed = int(output.split('=')[1]) / 1_000_000
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'N/A\n'
`