### PR TITLE
fix multiple log files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
 +--------------------------------+
+June 10 2025  Version 1.0.26
++--------------------------------+
+
+- Fix #40 `ffcuesplitter.log incomplete when there are multiple .cue files in
+  the same directory.
+
++--------------------------------+
 October 22 2024  Version 1.0.25
 +--------------------------------+
 

--- a/ffcuesplitter/about.py
+++ b/ffcuesplitter/about.py
@@ -25,9 +25,9 @@ This file is part of FFcuesplitter.
 AUTHOR = "Gianluca Pernigotto - Jeanslack"
 CONTACT = '<jeanlucperni@gmail.com>'
 MAINTAINER = "Gianluca Pernigotto - Jeanslack"
-COPYLEFT = '2024'
-VERSION = '1.0.25'
-RELEASE = 'October 21 2024'
+COPYLEFT = '2025'
+VERSION = '1.0.26'
+RELEASE = 'June 10 2025'
 APPNAME = "FFcuesplitter"
 PKGNAME = "ffcuesplitter"
 LICENSE_NAME = "GPL3 (Gnu Public License)"

--- a/ffcuesplitter/cuesplitter.py
+++ b/ffcuesplitter/cuesplitter.py
@@ -144,10 +144,11 @@ class FFCueSplitter(FFMpeg):
             self.kwargs['outputdir'] = self.kwargs['dirname']
         else:
             self.kwargs['outputdir'] = os.path.abspath(outputdir)
-        self.kwargs['logtofile'] = os.path.join(self.kwargs['outputdir'],
-                                                'ffcuesplitter.log')
+        basename = os.path.basename(self.kwargs['filename'])
+        fname = os.path.splitext(basename)[0]
+        logn = f'{fname}.ffcuesplitter.log'
+        self.kwargs['logtofile'] = os.path.join(self.kwargs['outputdir'], logn)
         self.kwargs['tempdir'] = '.'
-
         self.audiotracks = None
         self.probedata = []
         self.cue_encoding = None  # data chardet
@@ -283,8 +284,11 @@ class FFCueSplitter(FFMpeg):
         if subdirs:
             self.kwargs['outputdir'] = os.path.join(self.kwargs['outputdir'],
                                                     subdirs)
+            basename = os.path.basename(self.kwargs['filename'])
+            fname = os.path.splitext(basename)[0]
+            logn = f'{fname}.ffcuesplitter.log'
             self.kwargs['logtofile'] = os.path.join(self.kwargs['outputdir'],
-                                                    'ffcuesplitter.log')
+                                                    logn)
         else:
             raise FFCueSplitterError(f"Invalid argument: "
                                      f"'{self.kwargs['collection']}'")


### PR DESCRIPTION
Closes #40 

This PR fixes overwriting of `ffcuesplitter.log` file when there are multiple CUE files in the same directory. With this PR the logs will be renamed according to the name of the respective CUE files thus avoiding possible overwriting.