### PR TITLE
Copy option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,9 +5,17 @@ June 10 2025  Version 1.0.26
 - Fix #40 `ffcuesplitter.log incomplete when there are multiple .cue files in
   the same directory.
 - Update copyleft Year.
-- Fix #37 `FFcuesplitter: error: argument --ffmpeg-add-params: expected one 
-  argument`. Updated help for `ffmpeg-add-params` parameter using the command 
+- Fix #37 `FFcuesplitter: error: argument --ffmpeg-add-params: expected one
+  argument`. Updated help for `ffmpeg-add-params` parameter using the command
   line.
+- Due to known issue in FFmpeg with cutting FLAC files, the `copy` option has
+  been removed from the `-f`, `--output-format` parser argument to splitting
+  FLAC files without re-encoding. To force this behavior, e.g. the source file
+  is not in FLAC format, use the `--ffmpeg-add-params` argument and add
+  `-c copy` parameter to split files without re-encoding, for instance:
+  `--ffmpeg-add-params='-c copy'`. This partially fix #37 too.
+- Changed `--format-type` argument to `--output-format` argument using command
+  line argparser.
 
 +--------------------------------+
 October 22 2024  Version 1.0.25

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,10 @@ June 10 2025  Version 1.0.26
 
 - Fix #40 `ffcuesplitter.log incomplete when there are multiple .cue files in
   the same directory.
-- Fix copyleft Year.
+- Update copyleft Year.
+- Fix #37 `FFcuesplitter: error: argument --ffmpeg-add-params: expected one 
+  argument`. Updated help for `ffmpeg-add-params` parameter using the command 
+  line.
 
 +--------------------------------+
 October 22 2024  Version 1.0.25

--- a/ffcuesplitter/cuesplitter.py
+++ b/ffcuesplitter/cuesplitter.py
@@ -103,7 +103,7 @@ class FFCueSplitter(FFMpeg):
                 one of ("artist+album", "artist", "album").
         outputformat:
                 output format, one of
-                ("wav", "flac", "mp3", "ogg", "opus", "copy").
+                ("wav", "flac", "mp3", "ogg", "opus").
         overwrite:
                 overwriting options, one of ("ask", "never", "always").
         ffmpeg_cmd:

--- a/ffcuesplitter/ffmpeg.py
+++ b/ffcuesplitter/ffmpeg.py
@@ -70,9 +70,9 @@ class FFMpeg:
         Returns:
             tuple(codec, outsuffix)
         """
-        if self.kwargs['outputformat'] == 'copy':
+        if '-c copy' in self.kwargs['ffmpeg_add_params']:
             self.outsuffix = os.path.splitext(sourcef)[1].replace('.', '')
-            codec = '-c copy'
+            codec = ''
         else:
             try:
                 self.outsuffix = self.kwargs['outputformat']

--- a/ffcuesplitter/main.py
+++ b/ffcuesplitter/main.py
@@ -128,10 +128,12 @@ def main():
                         default='info'
                         )
     parser.add_argument("--ffmpeg-add-params",
-                        metavar="'parameters'",
-                        help=("Additionals ffmpeg parameters, as 'codec "
-                              "quality, bitrate, etc'. Note that additional "
-                              "parameters must be quoted."),
+                        metavar="parameters",
+                        help=("Additionals ffmpeg parameters. Note that the "
+                              "additional parameters must be quoted using "
+                              "single quotes and must be preceded by an "
+                              "equals sign (=), example: "
+                              "--ffmpeg-add-params='-c:a flac -ar 44100'."),
                         required=False,
                         default=''
                         )
@@ -162,6 +164,9 @@ def main():
                         default='info'
                         )
     args = parser.parse_args()
+
+    print(args)
+    return
 
     find = FileFinder(args.input_fd)  # get all cue files
     if args.recursive is True:

--- a/ffcuesplitter/main.py
+++ b/ffcuesplitter/main.py
@@ -81,8 +81,8 @@ def main():
                               "have no effect with filenames."),
                         required=False,
                         )
-    parser.add_argument('-f', '--format-type',
-                        choices=["wav", "flac", "mp3", "ogg", "opus", "copy"],
+    parser.add_argument('-f', '--output-format',
+                        choices=["wav", "flac", "mp3", "ogg", "opus"],
                         help=("Preferred audio format to output, "
                               "default is 'flac'."),
                         required=False,
@@ -183,7 +183,7 @@ def main():
         kwargs = {'filename': files}
         kwargs['outputdir'] = args.outputdir
         kwargs['collection'] = args.collection
-        kwargs['outputformat'] = args.format_type
+        kwargs['outputformat'] = args.output_format
         kwargs['overwrite'] = args.overwrite
         kwargs['ffmpeg_cmd'] = args.ffmpeg_cmd
         kwargs['ffmpeg_loglevel'] = args.ffmpeg_loglevel

--- a/ffcuesplitter/main.py
+++ b/ffcuesplitter/main.py
@@ -165,9 +165,6 @@ def main():
                         )
     args = parser.parse_args()
 
-    print(args)
-    return
-
     find = FileFinder(args.input_fd)  # get all cue files
     if args.recursive is True:
         allfiles = find.find_files_recursively(suffix=('.cue', '.CUE'))


### PR DESCRIPTION
This PR partially fixes #37 . 

Due to known issue in FFmpeg with cutting FLAC files, the `copy` option has been removed from the `-f`, `--output-format` parser argument to splitting FLAC files without re-encoding. To force this behavior, e.g. the source file is not in FLAC format, use the `--ffmpeg-add-params` argument and add `-c copy` parameter to split files without re-encoding, for instance: `--ffmpeg-add-params='-c copy'`

In addition, the `--format-type` argument is changed in `--output-format` argument using command line argparser.